### PR TITLE
Allow substitutions in custom_nanopb_protos

### DIFF
--- a/generator/platformio_generator.py
+++ b/generator/platformio_generator.py
@@ -39,7 +39,7 @@ generated_src_dir = os.path.join(build_dir, 'nanopb', 'generated-src')
 generated_build_dir = os.path.join(build_dir, 'nanopb', 'generated-build')
 md5_dir = os.path.join(build_dir, 'nanopb', 'md5')
 
-nanopb_protos = env.GetProjectOption("custom_nanopb_protos", "")
+nanopb_protos =  env.subst(env.GetProjectOption("custom_nanopb_protos", ""))
 nanopb_plugin_options = env.GetProjectOption("custom_nanopb_options", "")
 
 if not nanopb_protos:


### PR DESCRIPTION
Right now, proto files can only be built in platformio from proto files in the parent repo (since they have stable path). If the proto files are in a library, the checkout path will be environment dependent, requiring an environment name substitution in the path.

Allows building protos found in libraries by using ${PIOENV} substitutions like so:

`custom_nanopb_protos = +<.pio/libdeps/${PIOENV}/some_library/proto/*.proto>`

I haven't extensively tested this change, but I can confirm that it works to solve the problem I ran into.

The expected change is simply that [interpolation of values](https://docs.platformio.org/en/latest/projectconf/interpolation.html) will now work on the custom_nanopb_protos platformio argument.